### PR TITLE
Removed the necessary entries from dockerignore.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,1 @@
-node_modules
 buildcache
-bin


### PR DESCRIPTION
The node modules and bin folder have to be included to copy to image since the CI was moved out of dockerfile.